### PR TITLE
Enable build and installation on Windows

### DIFF
--- a/PyTransport/PyTrans/moduleSetup.py
+++ b/PyTransport/PyTrans/moduleSetup.py
@@ -16,7 +16,7 @@
 
 #module setup script
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import numpy
 import time
 import os
@@ -34,9 +34,9 @@ for line in lines:
     if line.startswith("// Package recompile"):
         f.write('// Package recompile attempted at: '+ time.strftime("%c") +'\n')
 f.close()        
-filename2 = os.path.join(dir, '../CppTrans/stepper/rkf45.cpp')
-dirs = os.path.join(dir, '../CppTrans/')
+filename2 = os.path.join(dir, '..', 'CppTrans', 'stepper', 'rkf45.cpp')
+dirs = os.path.join(dir, '..', 'CppTrans')
 
 # don't edit the comment at the end of the setup line below #######################################
-setup(name="PyTransQuartAxNC", version="1.0", ext_modules=[Extension("PyTransQuartAxNC", [filename, filename2 ])], include_dirs=[numpy.get_include(), dirs])#setup
+setup(name="PyTransDQuadNC", version="1.0", ext_modules=[Extension("PyTransDQuadNC", [filename, filename2 ])], include_dirs=[numpy.get_include(), dirs])#setup
 ###################################################################################################

--- a/PyTransport/PyTransSetup.py
+++ b/PyTransport/PyTransSetup.py
@@ -76,10 +76,10 @@ def pathSet():
 
     p = platform.system()
     if p is 'Windows':
-        site.addsitedir(os.path.join(dir, 'Python', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'Python', 'Lib', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'Python' + sys.version[:3].translate(None, '.'), 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'Python' + sys.version[:3].translate(None, '.'), 'Lib', 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'Lib', 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'Lib', 'site-packages'))
     else:
         site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python', 'site-packages'))
         site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python' + sys.version[:3], 'site-packages'))
@@ -127,10 +127,10 @@ def compileName(name,NC=False):
 
     p = platform.system()
     if p is 'Windows':
-        site.addsitedir(os.path.join(dir, 'Python', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'Python', 'Lib', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'Python' + sys.version[:3].translate(None, '.'), 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'Python' + sys.version[:3].translate(None, '.'), 'Lib', 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'Lib', 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'Lib', 'site-packages'))
     else:
         site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python', 'site-packages'))
         site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python' + sys.version[:3], 'site-packages'))
@@ -181,10 +181,10 @@ def compileName3(name,NC=False):
 
     p = platform.system()
     if p is 'Windows':
-        site.addsitedir(os.path.join(dir, 'Python', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'Python', 'Lib', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'Python' + sys.version[:3].translate(None, '.'), 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'Python' + sys.version[:3].translate(None, '.'), 'Lib', 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'Lib', 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'site-packages'))
+        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'Lib', 'site-packages'))
     else:
         site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python', 'site-packages'))
         site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python' + sys.version[:3], 'site-packages'))

--- a/PyTransport/PyTransSetup.py
+++ b/PyTransport/PyTransSetup.py
@@ -125,18 +125,7 @@ def compileName(name,NC=False):
     p = subprocess.Popen(["python", filename1, "install", "--user"], cwd=location, stdin=subprocess.PIPE, stderr=subprocess.PIPE, env=my_env)
     stdout, stderr = p.communicate()
 
-    p = platform.system()
-    if p is 'Windows':
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'Lib', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'Lib', 'site-packages'))
-    else:
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python' + sys.version[:3], 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'site-python'))
-
-    site.addsitedir(os.path.join(location, '..', 'PyTransScripts'))
+    pathSet()
 
     shutil.rmtree(os.path.join(location, 'build'), ignore_errors=True)
 
@@ -179,18 +168,7 @@ def compileName3(name,NC=False):
     p = subprocess.Popen(["python", filename1, "install", "--user"], cwd=location, stdin=subprocess.PIPE, stderr=subprocess.PIPE, env=my_env)
     stdout, stderr = p.communicate()
 
-    p = platform.system()
-    if p is 'Windows':
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python', 'Lib', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'Python' + sys.version[:3].translate(None, '.'), 'Lib', 'site-packages'))
-    else:
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python', 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'python' + sys.version[:3], 'site-packages'))
-        site.addsitedir(os.path.join(dir, 'PyTrans', 'lib', 'site-python'))
-
-    site.addsitedir(os.path.join(location, '..', 'PyTransScripts'))
+    pathSet()
 
     shutil.rmtree(os.path.join(location, 'build'), ignore_errors=True)
 


### PR DESCRIPTION
Since _PyTransport_ is standard Python, it should run fine on Windows. At the moment it won't install, but the only obstructions seem to be with compiling and installing the Python packages for each inflationary model. The key obstructions are:

- `distutils` can't find the Visual C++ compiler. This is a showstopper. It appears that there is not possible to install new Python packages under Windows using anything other than `setuptools`. (See, eg. https://www.microsoft.com/en-gb/download/details.aspx?id=44266 and skip to **Install Instructions**.)

- there are a number of hardcoded paths in `moduleSetup.py` and `PyTransSetup.py` that assume _PyTransport_ is running on a UNIX-like system. But this is easily fixable; `os.path.join` can join any number of leaf elements together to make a properly-separated path for whatever platform it is running on.

I also made a few other changes:

- instead of using `sys.path.append()` to add paths to the Python search list, I've used `site.addsitedir()` which is the preferred method (eg. it filters for duplicates)

- in order to get `setuptools` to install correctly, the `PYTHONUSERBASE` environment variable needs to be set to point to the install path. This means I've had to switch `subprocess.call()` for the slightly more complex `subprocess.Popen()`, which allows a modified environment to be passed to the newly spawned subprocess

- we found it was necessary to add `ignore_errors=True` to the `rmtree()` invocation. On Windows there doesn't seem to be a `build` folder left in-tree, so otherwise this fails because the folder cannot be found. (Probably Visual C++ uses a different temporary location.)

With these changes, _PyTransport_ now builds and works for me on Windows 10 using Pythonxy.